### PR TITLE
Fix indentation, when embedded blocks, it messes with <pre> contents

### DIFF
--- a/layouts/main.handlebars
+++ b/layouts/main.handlebars
@@ -36,14 +36,14 @@
 <div class="container">
     <div class="row">
         <div class="span3">
-	    {{>sidebar}}
+{{>sidebar}}
         </div>
         <div class="span9">
-            {{>options}}
+{{>options}}
             <div class="apidocs">
                 <div id="docs-main">
                     <div class="content">
-                        {{>layout_content}}
+{{>layout_content}}
                     </div>
                 </div>
             </div>

--- a/layouts/xhr.handlebars
+++ b/layouts/xhr.handlebars
@@ -1,6 +1,6 @@
 <div id="docs-main">
     <div class="content">
-        {{>layout_content}}
+{{>layout_content}}
     </div>
 </div>
 

--- a/partials/classes.handlebars
+++ b/partials/classes.handlebars
@@ -118,7 +118,7 @@
     <div class="constructor yuidoc-class-constructor page-section">
         <h2>Constructor</h2>
         <div class="item-list">
-        {{>method}}
+{{>method}}
         </div>
     </div>
 {{/is_constructor}}
@@ -130,7 +130,7 @@
        		{{#methods}}
         	{{#if static}}
             {{else}}
-            {{>method}}
+{{>method}}
             {{/if}}
         {{/methods}}
         </div>
@@ -143,7 +143,7 @@
 
         <div class="item-list">
         {{#properties}}
-            {{>props}}
+{{>props}}
         {{/properties}}
         </div>
     </div>
@@ -154,7 +154,7 @@
         <h2 class="off-left">Attributes</h2>
 
         {{#attrs}}
-            {{>attrs}}
+{{>attrs}}
         {{/attrs}}
     </div>
 {{/if}}
@@ -165,7 +165,7 @@
 
         <div class="item-list">
         {{#events}}
-            {{>events}}
+{{>events}}
         {{/events}}
         </div>
     </div>
@@ -177,7 +177,7 @@
         <div class="item-list">
         {{#methods}}
 			{{#if static}}
-    	        {{>method}}
+{{>method}}
             {{/if}}
         {{/methods}}
         </div>


### PR DESCRIPTION
Added before/after pictures so I don't have to write anything :)

Before:
![before](https://cdn.img42.com/b50f64f754275dcb6894da38fbdf014d.png)

After:
![before](https://cdn.img42.com/87d67efeec58375c3bd1d9fe7a1a96cc.png)
