### PR TITLE
Add filtering to the Table of Contents

### DIFF
--- a/assets/js/yuidoc-bootstrap.js
+++ b/assets/js/yuidoc-bootstrap.js
@@ -62,7 +62,7 @@ $(function() {
         var cssName = $.trim(box.parent('label').text()).toLowerCase();
         if(box.is(':checked')){
             $('div.'+cssName).css('display', 'block');
-            $('li.'+cssName).css('display', 'block');
+            $('li.'+cssName).css('display', 'list-item');
             $('span.'+cssName).css('display', 'inline');
         }else{
             $('.'+cssName).css('display', 'none');

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -13,6 +13,15 @@ module.exports = {
 
 		return ret;
 	},
+	filteringClassnames: function() {
+		return [
+			this.access,
+			this.deprecated && 'deprectated',
+			this.extended_from && 'inherited'
+		].filter(function (x) {
+			return !!x;
+		}).join(' ');
+	},
 	/**
 	 * Hack for:
 	 * https://github.com/yui/yuidoc/issues/198

--- a/partials/attrs.handlebars
+++ b/partials/attrs.handlebars
@@ -1,4 +1,4 @@
-<div id="attr-{{name}}" class="attr item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+<div id="attr-{{name}}" class="attr item {{filteringClassnames}}">
     <a name="config_{{name}}"></a> {{! For backwards compatibility }}
     <h3 class="name"><code>{{name}}</code></h3>
     <span class="type">{{#crossLink type}}{{/crossLink}}</span>

--- a/partials/classes.handlebars
+++ b/partials/classes.handlebars
@@ -68,7 +68,7 @@
 				{{#methods}}
 				{{#if static}}
 				{{else}}
-				<li><a href="#method-{{name}}"><span class="im">{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
+				<li class="{{filteringClassnames}}"><a href="#method-{{name}}"><span class="im">{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
 				{{/if}}
 				{{/methods}}
 			</ul>
@@ -80,7 +80,7 @@
 			<strong>Properties</strong>
 			<ul>
 				{{#properties}}
-				<li><a href="#prop-{{name}}"><span class="ip">{{name}}</span></a></li>
+				<li class="{{filteringClassnames}}"><a href="#prop-{{name}}"><span class="ip">{{name}}</span></a></li>
 				{{/properties}}
 			</ul>
 		</li>
@@ -91,7 +91,7 @@
 			<strong>Attributes</strong>
 			<ul>
 				{{#attrs}}
-				<li><a href="#attr-{{name}}"><span class="iattr">{{name}}</span></a></li>
+				<li class="{{filteringClassnames}}"><a href="#attr-{{name}}"><span class="iattr">{{name}}</span></a></li>
 				{{/attrs}}
 			</ul>
 		</li>
@@ -103,7 +103,7 @@
 			<ul>
 				{{#methods}}
 				{{#if static}}
-				<li><a href="#method-{{name}}"><span class="im">{{class}}.{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
+				<li class="{{filteringClassnames}}"><a href="#method-{{name}}"><span class="im">{{class}}.{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
 				{{/if}}
 				{{/methods}}
 			</ul>

--- a/partials/events.handlebars
+++ b/partials/events.handlebars
@@ -1,4 +1,4 @@
-<div id="event_{{name}}" class="events item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+<div id="event_{{name}}" class="events item {{filteringClassnames}}">
     <h3 class="name"><code>{{name}}</code></h3>
     <span class="type">{{#crossLink type}}{{/crossLink}}</span>
 

--- a/partials/method.handlebars
+++ b/partials/method.handlebars
@@ -1,4 +1,4 @@
-<div id="method-{{name}}" class="method item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+<div id="method-{{name}}" class="method item {{filteringClassnames}}">
 	<div class="method-signature">
 	<span class="name"><code>{{#if static}}{{class}}.{{/if}}{{name}}</code></span>
 

--- a/partials/props.handlebars
+++ b/partials/props.handlebars
@@ -1,4 +1,4 @@
-<div id="prop-{{name}}" class="property item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+<div id="prop-{{name}}" class="property item {{filteringClassnames}}">
     <h3 class="name"><code>{{name}}</code></h3>
     <span class="type">{{#crossLink type}}{{/crossLink}}</span>
 


### PR DESCRIPTION
The checkboxes that allow you to filter the visible documentation by 'private', 'deprecated', etc now also filter the table of contents at the top of the class view.

![filter_toc](https://cloud.githubusercontent.com/assets/1615761/19985514/3eff31f4-a1d0-11e6-9abd-057e217850ad.gif)

I originally implemented this as a one-off in https://github.com/molleindustria/p5.play/pull/122 - then realized I should submit it here!